### PR TITLE
add default-features to feature-profile-thunk

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -46,5 +46,5 @@
         body ...)
      #'(custom-profile e-fs q? body ...)]))
 
-(define (feature-profile-thunk thunk #:features [e-fs '()] #:quiet? [q? #f])
+(define (feature-profile-thunk thunk #:features [e-fs default-features] #:quiet? [q? #f])
   (feature-profile/user #:features e-fs #:quiet? q? (thunk)))


### PR DESCRIPTION
Currently, calling `feature-profile-thunk` without any features defaults to an empty set of features.
This is different from what the [docs](http://pkg-build.racket-lang.org/doc/feature-profile/index.html#%28form._%28%28lib._feature-profile%2Fmain..rkt%29._feature-profile%29%29) say.

Here's a simple fix.